### PR TITLE
Update Minecraft dependency version constraint

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.16.7",
-		"minecraft": "~1.21.2",
+		"minecraft": ">=1.21.2",
 		"java": ">=21",
 		"fabric-api": ">=0.106.0+1.21.2"
 	},


### PR DESCRIPTION
To allow for it to work on versions other than 1.21 (i.e upcoming 26.1)